### PR TITLE
Tie the Revit connection to the process and apply the parallel limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ It adds only the Revit execution model on top of TUnit; assertions, attributes, 
 ## Non-negotiables
 
 * One thread owns the Revit API. Every API call runs on the thread that initialized Revit; the executor marshals test bodies and hooks onto it and caps Revit tests to one at a time. Never touch a Revit type off that thread, and never start a second thread or `Task.Run` for Revit work.
-* Inject and eject in matched pairs. The application connects once per test session and releases on the matching session-teardown hook.
+* Inject and eject in matched pairs, once per process. The application connects in the first session that needs it and releases when the test application finishes (`RevitApplicationLifetime`), never per session: Revit's core cannot be loaded into a process twice, and hosts such as Visual Studio Test Explorer run many sessions in one process.
 * The package adds the Revit execution model only. It exposes the base classes, the executor, and the injection lifecycle; assertions, attributes, and discovery come from TUnit. Never reimplement what TUnit provides.
 * Never break the public surface. Deprecate a renamed member with `[Obsolete]`, name the replacement, and keep the member functional.
 * Mark a member the test platform invokes but consumers must not call `[EditorBrowsable(EditorBrowsableState.Never)]`.
@@ -21,7 +21,7 @@ It adds only the Revit execution model on top of TUnit; assertions, attributes, 
 * A process-wide singleton starts one background STA thread and runs a WPF `Dispatcher` on it. The dispatcher pumps the Win32 messages COM marshaling needs and routes `await` continuations through `DispatcherSynchronizationContext`.
 * `RevitThreadExecutor` is the public entry point. It queues the action onto the thread host and returns a task that completes once the body and its continuations finish. Unwrap the dispatcher operation (`operation.Task.Unwrap()`) to await the continuations.
 * A `IParallelLimit` returning `1` holds the Revit thread exclusive; two tests cannot share it.
-* `RevitApplicationTest` holds the static `Application`. `RevitApiTest` opens the connection before the session and closes it after, both on the Revit thread.
+* `RevitApplicationTest` holds the static `Application`. `RevitApiTest` opens the connection before the first session and `RevitApplicationLifetime` closes it after the test application, both on the Revit thread.
 
 ## Repository map
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Unreleased
+
+- The Revit connection now lives as long as the test host process instead of one test session.
+  Hosts that run several sessions in one process, such as Visual Studio Test Explorer in testing platform server mode, failed every run after the first with
+  `BeforeTestSession hook failed: Attempted to write protected memory.`, because Revit's core cannot be loaded into a process twice.
+  `RevitSessionSetup` injects once per process; the new `RevitApplicationLifetime` releases the connection when the test application finishes and is registered through the package's `build` props, so consuming projects need no change.
+  `RevitApiTest.RevitSessionCleanup` no longer runs as a hook and is obsolete.
+- Revit tests run one at a time again. TUnit's `TestExecutorAttribute` does not forward `ITestRegisteredEventReceiver` to the executor it creates, so the limit `RevitThreadExecutor` declares was never applied.
+  `RevitApplicationTest` now carries `[ParallelLimiter<RevitCountParallelLimit>]`, inherited by every Revit test; `RevitCountParallelLimit` is public.
+
 # 2027.0.1
 
 - Updated TUnit to 1.44

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Settings > Build, Execution, Deployment > Unit Testing > Testing Platform.
 
 ![](https://github.com/user-attachments/assets/d64c58f6-9223-4bdb-a513-c663daf4e0c1)
 
+### Visual Studio
+
+Enable **Tools > Manage Preview Features > Use testing platform server mode**; without it Test Explorer does not list the tests.
+
+Test Explorer keeps the test host process alive between runs and starts a new test session for each run. Revit is loaded into that process
+once, by the first run, and released when the host exits, so the first run pays the Revit start-up cost and later runs in the same host reuse
+the loaded application.
+
 ## Application testing
 
 Test Revit application-level functionality using the `Application` property exposed by `RevitApiTest`:

--- a/source/Nice3point.TUnit.Revit/Executors/RevitThreadExecutor.cs
+++ b/source/Nice3point.TUnit.Revit/Executors/RevitThreadExecutor.cs
@@ -19,6 +19,10 @@ public sealed class RevitThreadExecutor : GenericAbstractExecutor, ITestRegister
     /// <summary>
     ///     Applies the Revit parallel limiter so registered tests never run concurrently.
     /// </summary>
+    /// <remarks>
+    ///     TUnit's <c>TestExecutorAttribute</c> does not forward this event to the executor it creates, so the
+    ///     limiter is also declared on <see cref="RevitApplicationTest" />, which every Revit test inherits.
+    /// </remarks>
     public ValueTask OnTestRegistered(TestRegisteredContext context)
     {
         context.SetParallelLimiter(RevitCountParallelLimit.Default);
@@ -33,12 +37,20 @@ public sealed class RevitThreadExecutor : GenericAbstractExecutor, ITestRegister
         ArgumentNullException.ThrowIfNull(action);
         return RevitDispatcherThread.Instance.InvokeAsync(action);
     }
+
+    /// <summary>
+    ///     Runs <paramref name="action" /> on the Revit thread outside of a test or hook.
+    /// </summary>
+    internal static ValueTask InvokeAsync(Func<ValueTask> action)
+    {
+        return RevitDispatcherThread.Instance.InvokeAsync(action);
+    }
 }
 
 /// <summary>
 ///     Restricts Revit API tests to a single concurrent execution.
 /// </summary>
-file sealed class RevitCountParallelLimit : IParallelLimit
+public sealed class RevitCountParallelLimit : IParallelLimit
 {
     /// <summary>
     ///     Shared instance used by every registered Revit test.

--- a/source/Nice3point.TUnit.Revit/Nice3point.TUnit.Revit.csproj
+++ b/source/Nice3point.TUnit.Revit/Nice3point.TUnit.Revit.csproj
@@ -35,6 +35,7 @@
         <None Include="..\..\.nuget\PackageIcon.png" PackagePath="images\" Pack="true" Visible="false"/>
         <None Include="..\..\LICENSE.md" PackagePath="" Pack="true" Visible="false"/>
         <None Include="..\..\README.md" PackagePath="" Pack="true" Visible="false"/>
+        <None Include="build\Nice3point.TUnit.Revit.props" PackagePath="build\" Pack="true"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Nice3point.TUnit.Revit/RevitApiTest.cs
+++ b/source/Nice3point.TUnit.Revit/RevitApiTest.cs
@@ -6,7 +6,7 @@ namespace Nice3point.TUnit.Revit;
 /// <summary>
 ///     Represents a test class for executing tests within the Revit environment.
 ///     This class provides dependency resolution, setup and cleanup methods for initializing and terminating
-///     the connection to the Revit API before and after the test session.
+///     the connection to the Revit API before the test session and after the test application.
 /// </summary>
 public abstract class RevitApiTest : RevitApplicationTest
 {
@@ -15,6 +15,9 @@ public abstract class RevitApiTest : RevitApplicationTest
     ///     This method is executed before the test session begins, ensuring that the
     ///     necessary prerequisites for the tests interacting with the Revit environment are satisfied.
     /// </summary>
+    /// <remarks>
+    ///     Only the first session in a process injects Revit; later sessions reuse the connection.
+    /// </remarks>
     [Before(TestSession)]
     [HookExecutor<RevitThreadExecutor>]
     public static void RevitSessionSetup()
@@ -24,11 +27,13 @@ public abstract class RevitApiTest : RevitApplicationTest
 
     /// <summary>
     ///     Cleans up the Revit session by terminating the connection to the Revit API.
-    ///     This method is executed after the test session concludes, ensuring that
-    ///     resources and connections related to the Revit environment are properly released.
     /// </summary>
-    [After(TestSession)]
-    [HookExecutor<RevitThreadExecutor>]
+    /// <remarks>
+    ///     No longer runs as a hook. The connection outlives the session because a test host can run
+    ///     many sessions in one process, and Revit's core cannot be loaded a second time; it is released
+    ///     by <see cref="RevitApplicationLifetime" /> when the test application finishes.
+    /// </remarks>
+    [Obsolete("The Revit connection is released when the test application finishes, not after each session. Calling this ends the connection for the rest of the process.")]
     public static void RevitSessionCleanup()
     {
         TerminateRevitConnection();

--- a/source/Nice3point.TUnit.Revit/RevitApplicationLifetime.cs
+++ b/source/Nice3point.TUnit.Revit/RevitApplicationLifetime.cs
@@ -1,0 +1,84 @@
+using System.ComponentModel;
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Extensions.TestHost;
+using Nice3point.TUnit.Revit.Executors;
+
+namespace Nice3point.TUnit.Revit;
+
+/// <summary>
+///     Releases the Revit connection when the test application finishes.
+/// </summary>
+/// <remarks>
+///     This is the one point that runs after the last test session in every host, the console host of
+///     <c>dotnet run</c> and <c>dotnet test</c> as well as the server host an IDE keeps alive between runs,
+///     and before the runtime starts shutting down. Ejecting later, from <c>AppDomain.ProcessExit</c>, is
+///     impossible: the runtime's shutdown flag is already set, so the dispatcher on the Revit thread refuses
+///     the work. Ejecting from any other thread throws, and skipping the eject stalls the process for minutes
+///     in Revit's native teardown.
+/// </remarks>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public sealed class RevitApplicationLifetime : ITestHostApplicationLifetime
+{
+    private static readonly TimeSpan EjectTimeout = TimeSpan.FromSeconds(30);
+
+    /// <inheritdoc />
+    public string Uid => nameof(RevitApplicationLifetime);
+
+    /// <inheritdoc />
+    public string Version => "1.0.0";
+
+    /// <inheritdoc />
+    public string DisplayName => "Revit application lifetime";
+
+    /// <inheritdoc />
+    public string Description => "Releases the Revit connection on the Revit thread when the test application finishes.";
+
+    /// <inheritdoc />
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    /// <inheritdoc />
+    public Task BeforeRunAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public async Task AfterRunAsync(int exitCode, CancellationToken cancellationToken)
+    {
+        if (!RevitApplicationTest.IsConnected)
+        {
+            return;
+        }
+
+        var eject = RevitThreadExecutor.InvokeAsync(() =>
+        {
+            RevitApplicationTest.ReleaseConnection();
+            return default;
+        }).AsTask();
+
+        // A stuck eject must not keep the host alive: a hung shutdown locks the output folder.
+        // The delay ignores the token so a cancelled run still gets its bounded eject attempt.
+        var completed = await Task.WhenAny(eject, Task.Delay(EjectTimeout)).ConfigureAwait(false);
+        if (completed == eject)
+        {
+            await eject.ConfigureAwait(false);
+        }
+    }
+}
+
+/// <summary>
+///     Registers <see cref="RevitApplicationLifetime" /> with the Microsoft.Testing.Platform builder.
+/// </summary>
+/// <remarks>
+///     Referenced by the <c>TestingPlatformBuilderHook</c> item the package's <c>build/Nice3point.TUnit.Revit.props</c>
+///     adds to every consuming project; the platform's build step compiles a call to <see cref="AddExtensions" />
+///     into the generated entry point.
+/// </remarks>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class RevitTestingPlatformBuilderHook
+{
+    /// <summary>
+    ///     Adds the Revit lifetime extension to the test application.
+    /// </summary>
+    public static void AddExtensions(ITestApplicationBuilder builder, string[] args)
+    {
+        builder.TestHost.AddTestHostApplicationLifetime(_ => new RevitApplicationLifetime());
+    }
+}

--- a/source/Nice3point.TUnit.Revit/RevitApplicationTest.cs
+++ b/source/Nice3point.TUnit.Revit/RevitApplicationTest.cs
@@ -1,5 +1,6 @@
 using Autodesk.Revit.ApplicationServices;
 using Nice3point.Revit.Injector;
+using Nice3point.TUnit.Revit.Executors;
 
 namespace Nice3point.TUnit.Revit;
 
@@ -7,9 +8,18 @@ namespace Nice3point.TUnit.Revit;
 ///     Represents an abstract base class for tests that require interaction with the Revit application environment.
 ///     Provides methods to initialize and terminate the connection to the Revit application.
 /// </summary>
+/// <remarks>
+///     The connection lives as long as the test host process. Revit's core can be loaded into a process
+///     only once, and a host such as Visual Studio Test Explorer runs many test sessions in one process,
+///     so the connection is opened by the first session that needs it and released when the test
+///     application finishes, not per session.
+/// </remarks>
+[ParallelLimiter<RevitCountParallelLimit>]
 public abstract class RevitApplicationTest
 {
+    private static readonly object InjectionLock = new();
     private static Injector? _injector;
+    private static bool _ejected;
 
     /// <summary>
     ///     Represents the database level Autodesk Revit Application, providing access to documents, options and other application wide data and settings.
@@ -19,18 +29,73 @@ public abstract class RevitApplicationTest
     /// <summary>
     ///     Initializes the connection to the Revit application.
     /// </summary>
+    /// <remarks>
+    ///     Injects the Revit core the first time it is called in the process; every later call is a no-op,
+    ///     so any number of test sessions can share one connection.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">The connection was already terminated in this process.</exception>
     protected static void InitializeRevitConnection()
     {
-        _injector = new Injector();
-        Application = _injector.InjectApplication();
+        lock (InjectionLock)
+        {
+            if (_ejected)
+            {
+                throw new InvalidOperationException(
+                    "The Revit connection was already terminated in this process. Revit's core cannot be loaded twice; start a new test host.");
+            }
+
+            if (_injector is not null)
+            {
+                return;
+            }
+
+            var injector = new Injector();
+            Application = injector.InjectApplication();
+            _injector = injector;
+        }
+    }
+
+    /// <summary>
+    ///     Whether the process holds a live Revit connection.
+    /// </summary>
+    internal static bool IsConnected
+    {
+        get
+        {
+            lock (InjectionLock)
+            {
+                return _injector is not null && !_ejected;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Entry point for <see cref="RevitApplicationLifetime" />, which is not a test class.
+    /// </summary>
+    internal static void ReleaseConnection()
+    {
+        TerminateRevitConnection();
     }
 
     /// <summary>
     ///     Terminates the connection to the Revit application.
     ///     Frees associated resources and properly closes the interaction with the Revit environment.
     /// </summary>
+    /// <remarks>
+    ///     Ejects the Revit core once; later calls are no-ops. After this, the connection cannot be
+    ///     re-established in the same process.
+    /// </remarks>
     protected static void TerminateRevitConnection()
     {
-        _injector?.EjectApplication();
+        lock (InjectionLock)
+        {
+            if (_injector is null || _ejected)
+            {
+                return;
+            }
+
+            _ejected = true;
+            _injector.EjectApplication();
+        }
     }
 }

--- a/source/Nice3point.TUnit.Revit/build/Nice3point.TUnit.Revit.props
+++ b/source/Nice3point.TUnit.Revit/build/Nice3point.TUnit.Revit.props
@@ -1,0 +1,14 @@
+<Project>
+
+    <!--
+        Releases the Revit connection when the test application finishes. Microsoft.Testing.Platform
+        compiles a call to the named type into the generated entry point of the consuming test project.
+    -->
+    <ItemGroup>
+        <TestingPlatformBuilderHook Include="Nice3point.TUnit.Revit.RevitApplicationLifetime">
+            <DisplayName>Revit application lifetime</DisplayName>
+            <TypeFullName>Nice3point.TUnit.Revit.RevitTestingPlatformBuilderHook</TypeFullName>
+        </TestingPlatformBuilderHook>
+    </ItemGroup>
+
+</Project>

--- a/tests/Nice3point.TUnit.Revit.Tests/Nice3point.TUnit.Revit.Tests.csproj
+++ b/tests/Nice3point.TUnit.Revit.Tests/Nice3point.TUnit.Revit.Tests.csproj
@@ -27,4 +27,7 @@
         <ProjectReference Include="..\..\source\Nice3point.TUnit.Revit\Nice3point.TUnit.Revit.csproj"/>
     </ItemGroup>
 
+    <!-- What the package delivers through build/Nice3point.TUnit.Revit.props; a project reference does not. -->
+    <Import Project="..\..\source\Nice3point.TUnit.Revit\build\Nice3point.TUnit.Revit.props"/>
+
 </Project>

--- a/tests/Nice3point.TUnit.Revit.Tests/ProcessLifetimeTests.cs
+++ b/tests/Nice3point.TUnit.Revit.Tests/ProcessLifetimeTests.cs
@@ -1,0 +1,36 @@
+using Nice3point.TUnit.Revit.Executors;
+
+namespace Nice3point.TUnit.Revit.Tests;
+
+/// <summary>
+///     The connection is process-wide: a host that runs several test sessions in one process, such as
+///     Visual Studio Test Explorer in testing platform server mode, must be able to run the session
+///     setup again and get the same application back.
+/// </summary>
+public sealed class ProcessLifetimeTests : RevitApiTest
+{
+    [Test]
+    public async Task RevitSessionSetup_SecondSessionInSameProcess_ReusesConnection()
+    {
+        // Arrange
+        var application = Application;
+
+        // Act
+        RevitSessionSetup();
+
+        // Assert
+        await Assert.That(Application).IsSameReferenceAs(application);
+        await Assert.That(Application.VersionNumber).IsNotEmpty();
+    }
+
+    [Test]
+    public async Task Limiter_RevitTest_RunsOneAtATime()
+    {
+        // Arrange & Act
+        var limiter = TestContext.Current!.Parallelism.Limiter;
+
+        // Assert
+        await Assert.That(limiter).IsTypeOf<RevitCountParallelLimit>();
+        await Assert.That(limiter!.Limit).IsEqualTo(1);
+    }
+}


### PR DESCRIPTION
Resolves #108.

## What changes

**Connection lifetime.** `InitializeRevitConnection` injects Revit the first time it is called in the process and is a no-op afterwards, so any number of test sessions share one connection. `RevitSessionCleanup` no longer runs as a hook; it stays callable and is marked obsolete. The new `RevitApplicationLifetime` (`ITestHostApplicationLifetime`) ejects on the Revit thread from `AfterRunAsync`, which both `ConsoleTestHost` and `ServerTestHost` call after the last session and before runtime shutdown. It is wired into the consumer's generated entry point by `build/Nice3point.TUnit.Revit.props` through a `TestingPlatformBuilderHook` item, the mechanism TUnit.Engine uses for its own hook, so consuming projects need no change. The test project imports the same props because a project reference does not deliver them.

Why not eject on the last `After(TestSession)`: there is no way to know it is the last one in a server-mode host. Why not `AppDomain.ProcessExit`: the runtime's shutdown flag is already set, so the WPF dispatcher aborts anything queued to the Revit thread. Ejecting from another thread throws and leaves a one-thread zombie; skipping the eject makes the native teardown stall for minutes.

**Parallel limit.** `RevitApplicationTest` carries `[ParallelLimiter<RevitCountParallelLimit>]`, which TUnit's generator copies onto every derived test class. `RevitCountParallelLimit` becomes public for that. `RevitThreadExecutor.OnTestRegistered` stays as is, with a remark that TUnit does not forward the event.

## Tests

- `ProcessLifetimeTests.RevitSessionSetup_SecondSessionInSameProcess_ReusesConnection` runs the session hook a second time in the same process and expects the same application back.
- `ProcessLifetimeTests.Limiter_RevitTest_RunsOneAtATime` expects `TestContext.Current.Parallelism.Limiter` to be `RevitCountParallelLimit` with limit 1.

## Verification

The changes come from a consumer suite (37 Revit database tests on the published 2026.1.1 package) where the same two fixes are applied on top of the package. With them the suite passes twice in one server-mode host, passes standalone with default parallelism, and the host exits with code 0 in both cases; before, standalone only passed with `--maximum-parallel-tests 1` and every Test Explorer run after the first failed.

I could not run this repository's own test project: `Nice3point.Revit.Injector` is only on the Nice3point GitHub Packages feed, which I cannot access. The source and test projects compile for `Debug.R26` (net8.0-windows) and `Debug.R24` (net48) against a stub of the injector's public surface, and the generated code was checked for the builder hook call in both targets and the inherited limiter attribute on the test classes. The two new tests have not been executed here; please run the suite before merging.

Docs: README (Visual Studio section), CHANGELOG (Unreleased), AGENTS.md (the inject/eject rule now describes the process-level pairing).
